### PR TITLE
Update sdk to org.gnome.Sdk//44

### DIFF
--- a/org.learningequality.Kolibri.Plugin.kolibri-zim-plugin.yaml
+++ b/org.learningequality.Kolibri.Plugin.kolibri-zim-plugin.yaml
@@ -3,7 +3,7 @@ id: org.learningequality.Kolibri.Plugin.kolibri-zim-plugin
 branch: "1.0"
 runtime: "org.learningequality.Kolibri"
 runtime-version: "stable"
-sdk: "org.gnome.Sdk//42"
+sdk: "org.gnome.Sdk//44"
 build-extension: true
 appstream-compose: false
 separate-locales: false


### PR DESCRIPTION
This is required for the newest update to Kolibri released in flathub/org.learningequality.Kolibri#63.